### PR TITLE
[feature] UIButton, UITextField + Combine 이벤트 구독

### DIFF
--- a/RunLog/RunLog/Sources/Util/Extension/UIButton+.swift
+++ b/RunLog/RunLog/Sources/Util/Extension/UIButton+.swift
@@ -1,0 +1,17 @@
+//
+//  UIButton+.swift
+//  RunLog
+//
+//  Created by 신승재 on 3/17/25.
+//
+
+import UIKit
+import Combine
+
+extension UIButton {
+    var publisher: AnyPublisher<Void, Never> {
+        controlPublisher(for: .touchUpInside)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+}

--- a/RunLog/RunLog/Sources/Util/Extension/UIControl+.swift
+++ b/RunLog/RunLog/Sources/Util/Extension/UIControl+.swift
@@ -1,0 +1,55 @@
+//
+//  UIControl+.swift
+//  RunLog
+//
+//  Created by 신승재 on 3/17/25.
+//
+
+import UIKit
+import Combine
+
+extension UIControl {
+    
+    func controlPublisher(for event: UIControl.Event) -> UIControl.EventPublisher {
+        .init(control: self, event: event)
+    }
+    
+    struct EventPublisher: Publisher {
+        typealias Output = UIControl
+        typealias Failure = Never
+        
+        let control: UIControl
+        let event: UIControl.Event
+        
+        func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, UIControl == S.Input {
+            let subscription = EventSubscription(control: control, subscrier: subscriber, event: event)
+            subscriber.receive(subscription: subscription)
+        }
+    }
+    
+    fileprivate class EventSubscription<EventSubscriber: Subscriber>: Subscription where EventSubscriber.Input == UIControl, EventSubscriber.Failure == Never {
+        
+        let control: UIControl
+        let event: UIControl.Event
+        var subscriber: EventSubscriber?
+        
+        init(control: UIControl, subscrier: EventSubscriber, event: UIControl.Event) {
+            self.control = control
+            self.subscriber = subscrier
+            self.event = event
+            
+            control.addTarget(self, action: #selector(handleEvent), for: event)
+        }
+        
+        func request(_ demand: Subscribers.Demand) {}
+        
+        func cancel() {
+            subscriber = nil
+            control.removeTarget(self, action: #selector(handleEvent), for: event)
+        }
+        
+        @objc func handleEvent() {
+            _ = subscriber?.receive(control)
+        }
+    }
+}

--- a/RunLog/RunLog/Sources/Util/Extension/UITextField+.swift
+++ b/RunLog/RunLog/Sources/Util/Extension/UITextField+.swift
@@ -1,0 +1,18 @@
+//
+//  UITextField.swift
+//  RunLog
+//
+//  Created by 신승재 on 3/17/25.
+//
+
+import UIKit
+import Combine
+
+extension UITextField {
+    var publisher: AnyPublisher<String, Never> {
+        controlPublisher(for: .editingChanged)
+            .compactMap { $0 as? UITextField }
+            .map { $0.text ?? "" }
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- close #32 

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->
디스코드에서 설명 드린 것 처럼 UIButton, UITextField에서 이벤트를 구독하여 쓸 수 있습니다. (참고한 [아티클](https://insubkim.tistory.com/457))

기존 addTarget 대비 다음과 같은 장점을 얻을 수 있습니다.
- 이벤트 하나당 함수하나 X, 한곳에서 관리할 수 있기 때문에 유지보수 및 가독성 증가
- 더 직관적인 데이터 흐름 작성
- 다양한 연산자(고차함수)를 활용하여 작성 가능

<img width="389" alt="image" src="https://github.com/user-attachments/assets/e7bda4c0-9670-439c-86a0-4d0fc7d96a91" />

예제 코드는 아래와 같습니다.
- UIButton
```swift
calendarView.arrowButton.publisher
            .sink {
                print("button Tapped")
            }
            .store(in: &cancellables)
```

- UITextField
```swift
calUnitView.unitField.publisher
            .sink { text in
                print(text)
            }.store(in: &cancellables)
```

또한, 이벤트를 일괄 구독하는 함수 네이밍은
setupGesture보다 bindGesture가 나을 것 같은데 어떠신가요?
```swift
// MARK: - Bind Gesture
private func BindGesture() {
    // 제스처 구독
   calendarView.arrowButton.publisher
            .sink {
                print("button Tapped")
            }
            .store(in: &cancellables)

    calUnitView.unitField.publisher
            .sink { text in
                print(text)
            }.store(in: &cancellables)
}
```